### PR TITLE
Include missing  block on secure lock screen strings

### DIFF
--- a/res/values/chroma_strings.xml
+++ b/res/values/chroma_strings.xml
@@ -456,4 +456,8 @@
     <string name="expanded_desktop_style_description">Choose a default expanded desktop style</string>
     <string name="expanded_desktop_title">Expanded desktop options</string>
 
+    <!-- Quicksettings block on secure lockscreen -->
+    <string name="qs_category">Quicksettings</string>
+    <string name="block_on_secure_keyguard_title">Disable on lockscreen</string>
+    <string name="block_on_secure_keyguard_summary">Disable quick settings on secure lockscreen.</string>
 </resources>


### PR DESCRIPTION
Include missing strings from https://github.com/zephiK/android_packages_apps_Settings/commit/471c42882a1936046d03c66f973559f963e0b2f7